### PR TITLE
fix: dropping slider

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,7 +308,8 @@ def layout(upazilano):
                                                                                     ),
                                                                                     dbc.Row(dcc.Graph(id="ULOSickLA")),
                                                                                     dbc.Row(dcc.Graph(id="ULODeadLA")),
-                                                                                ]
+                                                                                ],
+                                                                                width=5,
                                                                             ),
                                                                             dbc.Col(
                                                                                 [
@@ -351,7 +352,8 @@ def layout(upazilano):
                                                                                     ),
                                                                                     dbc.Row(dcc.Graph(id="ULOSickP")),
                                                                                     dbc.Row(dcc.Graph(id="ULODeadP")),
-                                                                                ]
+                                                                                ],
+                                                                                width=5,
                                                                             ),
                                                                             dbc.Col(
                                                                                 [


### PR DESCRIPTION
## Description

the width of a page is subdivided into 12 sections.the right side consist of the graph and a slim slider. The slide was defined as having the "thickness" of 1, but the graph was undefined. 
This PR sets it to 5

closes #4

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the road86 Contribution Guide.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
